### PR TITLE
make simple-rod be a simple-array or a simple-base-string on SBCL

### DIFF
--- a/runes/characters.lisp
+++ b/runes/characters.lisp
@@ -26,7 +26,7 @@
 
 (deftype rune () #-lispworks 'character #+lispworks 'lw:simple-char)
 (deftype rod () '(vector rune))
-(deftype simple-rod () '(simple-array rune (*)))
+(deftype simple-rod () #-sbcl '(simple-array rune) #+sbcl '(or (simple-array rune) simple-base-string))
 
 (definline rune (rod index)
   (char rod index))

--- a/runes/characters.lisp
+++ b/runes/characters.lisp
@@ -25,7 +25,7 @@
 (in-package :fxml.runes)
 
 (deftype rune () #-lispworks 'character #+lispworks 'lw:simple-char)
-(deftype rod () '(vector rune))
+(deftype rod () #-sbcl '(vector rune) #+sbcl '(or (vector rune) simple-base-string))
 (deftype simple-rod () #-sbcl '(simple-array rune) #+sbcl '(or (simple-array rune) simple-base-string))
 
 (definline rune (rod index)

--- a/stp/element.lisp
+++ b/stp/element.lisp
@@ -63,7 +63,7 @@
    @arg[uri]{a string, the namespace URI}
    @return{an @class{element}}
    @short{This function creates an element node of the given name.}"
-  (check-type name runes:rod)
+  (check-type name fxml.runes:rod)
   (let ((result (make-instance 'element)))
     (multiple-value-bind (prefix local-name)
 	(fxml:split-qname name)
@@ -312,7 +312,7 @@
                                             (if (and (listp entry) (cdr entry))
                                                 entry
                                                 (list entry (coerce (string-downcase entry)
-                                                                    'runes:simple-rod)))
+                                                                    'fxml.runes:simple-rod)))
                                           `(,var (attribute-value ,element ,name ,uri))))
                                       entries)
                            ,@body)))

--- a/xml/unparse.lisp
+++ b/xml/unparse.lisp
@@ -73,7 +73,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel)
   (defvar *basic-keywords*
-    '(canonical indentation encoding omit-xml-declaration)))
+    '(canonical indentation text-indentation encoding omit-xml-declaration)))
 
 ;;;; SINK: an xml output sink
 
@@ -82,6 +82,7 @@
    (width :initform 79 :initarg :width :accessor width)
    (canonical :initform nil :initarg :canonical :accessor canonical)
    (indentation :initform nil :initarg :indentation :accessor indentation)
+   (text-indentation :initform nil :initarg :text-indentation :accessor text-indentation)
    (current-indentation :initform 0 :accessor current-indentation)
    (notations :initform (make-buffer :element-type t) :accessor notations)
    (name-for-dtd :accessor name-for-dtd)
@@ -568,7 +569,7 @@
       (map nil (lambda (c) (sink-write-rune c sink)) data)
       (sink-write-rod #"]]>" sink))
     (t
-      (if (indentation sink)
+      (if (text-indentation sink)
           (unparse-indented-text data sink)
           (if (canonical sink)
               (sink-write-escapable-rod/canonical data sink)


### PR DESCRIPTION
Would appreciate some input on whether or not this is the right thing to do, but it fixes my problem.